### PR TITLE
Misc updates to explainer based on feedback

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -133,11 +133,11 @@ When an `launch` event is captured as the result of a redirect, the behavior of 
 - The tab could be closed. This would be good behavior if a tab was only opened to process the navigation before it could be captured by the app.
 - The tab could return to the page it was on prior to the navigation starting. This seems like sensible behavior in the general case, allowing the user to continue on the site they were on prior to clicking the link handled by the launch event. The user may lose state on the site as a result of a navigation happening, but this wouldn't be unexpected since they've clicked a link.
 
-### Handling window.open()
+### Handling `window.open()`
 
-Ideally calls to window.open() would also be possible for sites to intercept and handle in a `launch` event handler without the new window opening. One challenge is that it's not sufficient to just examine the URL that's passed into window.open() and intercept it as a launch event as it may trigger a redirect as described above.
+Ideally calls to `window.open()` would also be possible for sites to intercept and handle in a `launch` event handler without the new window opening. One challenge is that it's not sufficient to just examine the URL that's passed into `window.open()` and intercept it as a launch event as it may trigger a redirect as described above.
 
-As a first cut, we propose not doing anything special for window.open(). A new window will be opened as usual and a navigation started. That navigation can trigger a launch event.
+As a first cut, we propose not doing anything special for `window.open()`. A new window will be opened as usual and a navigation started. That navigation can trigger a launch event.
 
 In future we can consider more advanced techniques to avoid opening a new window and improve the user experience.
 

--- a/explainer.md
+++ b/explainer.md
@@ -8,9 +8,19 @@ Author: Raymes Khoury &lt;<raymes@chromium.org>&gt;
 Created: 2017-09-22
 Updated: 2019-05-27
 
-## Introduction
+## Introduction and Motivation
 
-This explainer proposes a new API for Service Workers that allows web applications to control which window/tab they will open in.
+Currently web apps have no control over how they will be launched. e.g. they have no control over whether launches will happen in a new window/tab or an existing window/tab that the web app controls. This explainer proposes a new API for Service Workers that allows web applications to control which window/tab they will open in.
+
+Examples of cases where this can be useful:
+* A chat web app runs in a single window. Users may receive links to specific chat rooms to open in that app. Clicking a link to a chat room should focus the existing window and open the chat room rather than opening a new instance of the chat app.
+* A music player might be playing a track; if the user clicks a link to another track, instead of opening a new tab to the track (possibly playing music over the existing music), it could focus the existing tab, show the new track info but keep playing the old track in the background.
+* A document editor could allow a separate window for each document, but if the user clicks a link to a document that is already open in a window, focus that window instead of opening a duplicate.
+* A video player might be playing a video. If the user clicks an external link to a second video, that video could be queued instead of interrupting playback.
+
+In some cases, web apps may not want to open a new window at all, and may be content to show a notification. e.g.
+* A "`magnet:`" URL is handled by a torrent client, which automatically starts downloading the file, showing a notification but not opening a new window or tab.
+* A "save for later" tool that has a share target. When the share target is chosen, it just shows a notification "Saved for later", but doesn't actually spawn a browsing context.
 
 Example Service Worker code to handle all launches of a web app in an existing window if one exists:
 
@@ -44,19 +54,6 @@ There are also ways to launch web apps which don't exist yet, but which we would
 1. **File Handlers:** A user opens a file that an Image Editor web app has registered to handle. ([Proposal](https://github.com/WICG/file-handling)).
 2. **Content Type Handlers:** A user navigates to a PDF and it is opened using a PDF viewer web app.
 3. **Deep-link shortcuts API**. A user clicks an OS action to compose a new email with an email client. They are taken to the compose screen of the email client. (Proposed API: [proposal 1](https://gist.github.com/kenchris/0acec2790cd38dfdff0a7197ff00d1de); [proposal 2](https://docs.google.com/a/chromium.org/document/d/1WzpCnpc1N7WjDJnFmj90-Z5SALI3cSPtNrYuH1EVufg/edit)). 
-
-## Motivating Examples
-
-Currently web apps have no control over how they will be launched. e.g. they have no control over whether launches will happen in a new window/tab or an existing window/tab that the web app controls. This explainer proposes a new API for Service Workers that allows web applications to control which window/tab they will open in.
-
-Examples:
-* A music player might be playing a track; if the user clicks a link to another track in the player's scope, instead of opening a new tab to the track (possibly playing music over the existing music), it could focus the existing tab, show the new track info but keep playing the old track in the background.
-* A document editor could allow a separate window for each document, but if the user clicks a link to a document that is already open in a window, focus that window instead of opening a duplicate.
-* A video player might be playing a video. If the user clicks an external link to a second video, that video could be queued instead of interrupting playback.
-
-In some cases, web apps may not want to open a new window at all, and may be content to show a notification. e.g.
-* A "`magnet:`" URL is handled by a torrent client, which automatically starts downloading the file, showing a notification but not opening a new window or tab.
-* A "save for later" tool that has a share target. When the share target is chosen, it just shows a notification "Saved for later", but doesn't actually spawn a browsing context.
 
 ## `launch` Event
 


### PR DESCRIPTION
- In the TAG review it was requested that motivating examples be moved to introduction 
- A new chat room example was added
- URL Request handlers -> Content type handlers
- Added a note about how launch events shouldn't be able to trigger other launch events
