### PR TITLE
Rename route_to to client_mode and associated values

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,13 +86,13 @@
           "url": "/discover"
         }],
         "launch_handler": {
-          "route_to": "existing-client-retain"
+          "client_mode": "focus-existing"
         }
       }
       </pre>
       <p>
-        The [=manifest/route_to=] parameter set to
-        [=route to/existing-client-retain=] causes app launches to bring
+        The [=manifest/client_mode=] parameter set to
+        [=client mode/focus-existing=] causes app launches to bring
         existing app instances (if any) into focus without navigating them away
         from their current document.
       </p>
@@ -150,7 +150,7 @@
         </p>
         <p class="note">
           [=manifest/launch_handler=] is a dictionary despite
-          [=manifest/route_to=] being the only member. This is to give room for
+          [=manifest/client_mode=] being the only member. This is to give room for
           more members to be added should other types of behaviors be needed in
           the future.
         </p>
@@ -167,67 +167,67 @@
           </li>
           <li>Set |manifest|["launch_handler"] to a new [=ordered map=].
           </li>
-          <li>[=Process the `route_to` member=] passing
+          <li>[=Process the `client_mode` member=] passing
           |json|["launch_handler"], |manifest|["launch_handler"].
           </li>
         </ol>
       </section>
       <section>
         <h3>
-          [=manifest/route_to=] member
+          [=manifest/client_mode=] member
         </h3>
         <p>
-          The <dfn data-dfn-for="manifest">`route_to`</dfn> member of the
+          The <dfn data-dfn-for="manifest">`client_mode`</dfn> member of the
           [=manifest/launch_handler=] is a [=string=] or list of [=strings=]
-          that specify one or more [=route to targets=]. A [=route to target=]
+          that specify one or more [=client mode targets=]. A [=client mode target=]
           declares a particular client selection and navigation behaviour to use
           for web apps launches.
         </p>
         <p>
-          User agents MAY support only a subset of the [=route to targets=]
+          User agents MAY support only a subset of the [=client mode targets=]
           depending on the constraints of the platform (e.g. mobile devices may
           not support multiple app instances simultaneously).
         </p>
         <p>
           <p>
-            The <dfn>route to targets</dfn> are as follows:
+            The <dfn>client mode targets</dfn> are as follows:
           </p>
           <dl>
             <dt>
-              <dfn data-dfn-for="route to">auto</dfn>
+              <dfn data-dfn-for="client mode">auto</dfn>
             </dt>
             <dd>
               The user agent's default launch routing behaviour is used.
               <p class="note">
                 The user agent is expected to decide what works best for the
                 platform. e.g., on mobile devices that only support single app
-                instances the user agent may use `existing-client-navigate`,
+                instances the user agent may use `navigate-existing`,
                 while on desktop devices that support multiple windows the user
-                agent may use `new-client` to avoid data loss.
+                agent may use `navigate-new` to avoid data loss.
               </p>
             </dd>
             <dt>
-              <dfn data-dfn-for="route to">new-client</dfn>
+              <dfn data-dfn-for="client mode">navigate-new</dfn>
             </dt>
             <dd>
               A new web app client is created to load the launch's target URL.
             </dd>
             <dt>
-              <dfn data-dfn-for="route to">existing-client-navigate</dfn>
+              <dfn data-dfn-for="client mode">navigate-existing</dfn>
             </dt>
             <dd>
               If an existing web app client is open it is brought to focus and
               navigated to the launch's target URL. If there are no existing web
-              app clients the [=route to/new-client=] behaviour is used instead.
+              app clients the [=client mode/navigate-new=] behaviour is used instead.
             </dd>
             <dt>
-              <dfn data-dfn-for="route to">existing-client-retain</dfn>
+              <dfn data-dfn-for="client mode">focus-existing</dfn>
             </dt>
             <dd>
               If an existing web app client is open it is brought to focus but
               not navigated to the launch's target URL, instead the target URL
               is communicated via {{LaunchParams}} . If there are no existing
-              web app clients the [=route to/new-client=] behaviour is used
+              web app clients the [=client mode/navigate-new=] behaviour is used
               instead.
               <p class="warning">
                 It is necessary for the page to have a {{LaunchConsumer}} set on
@@ -239,42 +239,42 @@
           </dl>
         </p>
         <p>
-          To <dfn>process the `route_to` member</dfn>, given [=ordered
+          To <dfn>process the `client_mode` member</dfn>, given [=ordered
           map=] |json_launch_handler:ordered map|, [=ordered map=]
           |manifest_launch_handler:ordered map|, run the following:
         </p>
         <ol class="algorithm">
-          <li>If |json_launch_handler|["route_to"] does not [=map/exist=],
+          <li>If |json_launch_handler|["client_mode"] does not [=map/exist=],
           return.
           </li>
-          <li>If the type of |json_launch_handler|["route_to"] is
+          <li>If the type of |json_launch_handler|["client_mode"] is
           [=list=]:
             <ol class="algorithm">
               <li>[=list/For each=] |entry| of
-                  |json_launch_handler|["route_to"]:
+                  |json_launch_handler|["client_mode"]:
                 <ol class="algorithm">
                   <li>If the type of |entry| is not [=string=], continue.
                   </li>
                   <li>If |entry| is supported by the user agent, set
-                      |manifest_launch_handler|["route_to"] to |entry| and
+                      |manifest_launch_handler|["client_mode"] to |entry| and
                       return.
                   </li>
                 </ol>
               </li>
             </ol>
           </li>
-          <li>If |json_launch_handler|["route_to"] is [=string=] and supported
-              by the user agent, set |manifest_launch_handler|["route_to"] to
-              |json_launch_handler|["route_to"] and return.
+          <li>If |json_launch_handler|["client_mode"] is [=string=] and supported
+              by the user agent, set |manifest_launch_handler|["client_mode"] to
+              |json_launch_handler|["client_mode"] and return.
           </li>
-          <li>Set |manifest_launch_handler|["route_to"] to [=route to/auto=].
+          <li>Set |manifest_launch_handler|["client_mode"] to [=client mode/auto=].
           </li>
         </ol>
         <p class="note">
-          `route_to` accepts a list of strings to allow sites to specify
-          fallback [=route to targets=] to use if the preferred [=route to
+          `client_mode` accepts a list of strings to allow sites to specify
+          fallback [=client mode targets=] to use if the preferred [=client mode
           target=] is not supported by the user agent or platform. The first
-          supported [=route to target=] entry in the list gets used.
+          supported [=client mode target=] entry in the list gets used.
         </p>
       </section>
     </section>
@@ -321,7 +321,7 @@
               {{LaunchParams/targetURL}} set to [=manifest/start_url=].
           </li>
           <li>Set |client| to the result of running the steps to
-              [=prepare a web app launch client=] passing [=manifest/route_to=]
+              [=prepare a web app launch client=] passing [=manifest/client_mode=]
               and |params|.{{LaunchParams/targetURL}}.
           </li>
           <li>Append |params| to the [=unconsumed launch params=] of the
@@ -352,18 +352,18 @@
           steps:
         </p>
         <ol class="algorithm">
-          <li>Let [=route to target=] |route_to| be
-              |manifest|["launch_handler"]["route_to"].
+          <li>Let [=client mode target=] |client_mode| be
+              |manifest|["launch_handler"]["client_mode"].
           </li>
-          <li>If |route_to| is [=route to/auto=], set |route_to| to either
-              [=route to/new-client=] or [=route to/existing-client-navigate=]
+          <li>If |client_mode| is [=client mode/auto=], set |client_mode| to either
+              [=client mode/navigate-new=] or [=client mode/navigate-existing=]
               according to the user agent's decision for which is most
               appropriate.
           </li>
           <li>
-            <p>Switching on |route to|, run the following substeps:</p>
+            <p>Switching on |client mode|, run the following substeps:</p>
             <dl class="switch">
-              <dt>[=route to/new-client=]</code>
+              <dt>[=client mode/navigate-new=]</code>
               <dd>
                 <ol class="algorithm">
                   <li>Return the result of running the steps to [=prepare a new
@@ -371,8 +371,8 @@
                       |target URL|.
                   </li>
                 </ol>
-              <dt>[=route to/existing-client-navigate=] or
-                  [=route to/existing-client-retain=]</code>
+              <dt>[=client mode/navigate-existing=] or
+                  [=client mode/focus-existing=]</code>
               <dd>
                 <ol class="algorithm">
                   <li>If there is no [=service worker client/window client=] for
@@ -384,7 +384,7 @@
                       for the web app, the exact selection algorithm is decided
                       by the user agent.
                   </li>
-                  <li>If |route to| is [=route to/existing-client-navigate=],
+                  <li>If |client mode| is [=client mode/navigate-existing=],
                       run the steps to [=navigate=] |client| to |target URL|.
                   </li>
                   <li>Return |client|.


### PR DESCRIPTION
Issue: https://github.com/WICG/sw-launch/issues/59

This change updates the `route_to` field to `client_mode`, this is a simple find and replace rename.

`route_to: auto` => `client_mode: auto`
`route_to: new-client` => `client_mode: navigate-new`
`route_to: existing-client-navigate` => `client_mode: navigate-existing`
`route_to: existing-client-retain` => `client_mode: focus-existing`